### PR TITLE
Expect Result when appropriate with nx API change

### DIFF
--- a/aoc-mitm/src/main.rs
+++ b/aoc-mitm/src/main.rs
@@ -43,7 +43,7 @@ pub fn main() -> Result<()> {
     fs::mount_sd_card("sdmc")?;
     mitm::scan_mitms()?;
 
-    let mut manager = Manager::new();
+    let mut manager = Manager::new()?;
     manager.register_mitm_service_server::<aoc::AddOnContentManager>()?;
     manager.loop_process()?;
 


### PR DESCRIPTION
[`nx`](https://github.com/aarch64-switch-rs/nx) had an API change with commit [27ee1ad](https://github.com/aarch64-switch-rs/nx/commit/27ee1ade5642ca10b7d0f4f08e250f946e1d57f0) that changed the return type of `nx::ipc::server::ServerManager::new()` from `ServerManager` to `Result<ServerManager, ResultCode>`. This led to a compilation error.

I fixed this by returning the error if there is one.